### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/grokify/aha-mcp-server/security/code-scanning/2](https://github.com/grokify/aha-mcp-server/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow to explicitly limit the permissions granted to GITHUB_TOKEN. For the CI job shown, only checkout and testing of code occur, meaning only read access to repository contents is needed. The best way to address this is to add the block at the workflow root (directly beneath the `name` key and before the `on:` key) so it applies globally. Alternatively, it could be added to the specific job, but the root applies to all jobs by default. This involves inserting:

```yaml
permissions:
  contents: read
```

at line 2, so that the structure now is:

```yaml
name: CI
permissions:
  contents: read
on:
  ...
```

No additional methods, imports, or code changes are necessary elsewhere.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
