### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,4 +1,6 @@
 name: lint
+permissions:
+  contents: read
 on: [push, pull_request]
 jobs:
   lint:


### PR DESCRIPTION
Potential fix for [https://github.com/grokify/aha-mcp-server/security/code-scanning/1](https://github.com/grokify/aha-mcp-server/security/code-scanning/1)

To fix this problem, add a `permissions:` block restricting the workflow’s (or just the job's) permissions to the minimum needed. In this context, since the workflow only checks out repository code and runs static analysis (linting), only `contents: read` is needed. You can add this block at the root of the workflow so all jobs inherit it, or at the job level for `lint`. The simplest and clearest way is to add it at the root, directly below `name:` and before `on:`.

- File to change: `.github/workflows/lint.yaml`
- Insert the following lines:
  ```yaml
  permissions:
    contents: read
  ```
  directly under the `name: lint` block, before the `on:` section.

No new methods or imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
